### PR TITLE
Add multiline formula and limits features to nearley

### DIFF
--- a/packages/nearley/package.json
+++ b/packages/nearley/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "test": "vitest --run",
-    "build": "tsup",
+    "build": "nearleyc src/parser.ne -o src/grammar.js && node src/after-build.js && tsup",
     "nearley": "nearleyc src/parser.ne -o src/grammar.js && node src/after-build.js",
     "cov": "vitest --run --coverage"
   },

--- a/packages/nearley/src/lexer.ts
+++ b/packages/nearley/src/lexer.ts
@@ -22,6 +22,7 @@ const initLexer = (symbols: Symbols) => {
   }
 
   const main = {
+    newlines: { match: /\n{2,}/, lineBreaks: true },
     newline: { match: '\n', lineBreaks: true },
     space: /[ \t]+/,
     number: /[0-9]+\.[0-9]+|[0-9]+/,

--- a/packages/nearley/src/parser.ne
+++ b/packages/nearley/src/parser.ne
@@ -22,17 +22,34 @@ const matrixPostProcess = (d, pipeIndex) => {
 
 const matrixRowPostProcess = (d) => {
   const pipeIndex = []
-  const offset = d[0] ? 1 : 0
+  const firstItem = String(d[0])
+  const hasHeadline = firstItem === 'hline' || firstItem === '--'
+  const offset = d[0] && !hasHeadline ? 1 : 0
   d[1].forEach((item, index) => {
     if (item[0][0].type === 'pipeEnd') {
       pipeIndex.push(index + offset)
     }
   })
   let value = [d[0], ...d[1].map(item => item[2])]
+
   // 允许 [|a, b|; c, d] => \begin{array}{|cc|}
   const begin = pipeIndex[0] === 0 ? 1 : 0
   const lastItem = d[1][d[1].length - 1]
   const end = lastItem?.[0]?.[0]?.type === 'pipeEnd' && lastItem?.[2] === null ? -1 : undefined
+
+  /* 允许 hline 写在竖线前, 如
+   * [
+   * hline
+   * |a|b|;
+   * ]
+   * 要实现这个功能, 只需把 hline 和竖线位置交换
+   */
+  if (hasHeadline && begin === 1) {
+    if (value[1])
+      value[1] = [d[0][0], ...value[1]]
+    else
+      value[1] = d[0]
+  }
   return { value: value.slice(begin, end), pipeIndex }
 }
 %}

--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -362,8 +362,8 @@ const symbols: Required<Symbols> = {
     '~|': { tex: '\\rceil' },
   },
   limits: {
-    '==': { tex: '\\xlongequal[ $2 ]{ $1 }' },
-    '-->': { tex: '\\xrightarrow[ $2 ]{ $1 }' },
+    '==': { tex: '\\xlongequal[ $1 ]{ $2 }' },
+    '-->': { tex: '\\xrightarrow[ $1 ]{ $2 }' },
   },
   sub: {
     '_+': { tex: '_{ +$1 }' },

--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -69,6 +69,7 @@ const symbols: Required<Symbols> = {
     'phi': { tex: '\\phi' },
     'varphi': { tex: '\\varphi' },
     'Phi': { tex: '\\Phi' },
+    'varPhi': { tex: '\\varPhi' },
     'chi': { tex: '\\chi' },
     'psi': { tex: '\\psi' },
     'Psi': { tex: '\\Psi' },
@@ -151,6 +152,7 @@ const symbols: Required<Symbols> = {
     '%': { tex: '\\%' },
     '\\_': { tex: '\\_' },
     '\\$': { tex: '\\$' },
+    '$': { tex: '\\$' },
     '\\^': { tex: '\\^' },
     '\\`': { tex: '\\`' },
 
@@ -212,6 +214,7 @@ const symbols: Required<Symbols> = {
     '\'\'\'': { tex: '^{\\prime\\prime\\prime}' },
     'laplace': { tex: '\\Delta' },
     'hline': { tex: '\\hline' },
+    '--': { tex: '\\hline' },
     '#': { tex: '\\displaystyle' },
     'mid': { tex: '\\mid' },
 

--- a/packages/nearley/src/to-tex.ts
+++ b/packages/nearley/src/to-tex.ts
@@ -65,9 +65,12 @@ const initGenerator = (symbols: Required<Symbols>) => {
   }
 
   const genLimits = (ast: Ast) => {
-    const { value, $1, $2 } = ast
+    const { value, sub, sup, $1, $2 } = ast
     const res = symbols.limits[value.value].tex
-    return res.replace('$1', toTex($1, true)).replace('$2', toTex($2, true))
+    const tex1 = sub ? toTex($1, true) : ''
+    const tex2 = sup ? toTex($2, true) : ''
+    return res.replace('$1', tex1)
+      .replace('$2', tex2)
   }
 
   const genSubSup = (ast: Ast) => {

--- a/packages/nearley/test/to-tex.test.ts
+++ b/packages/nearley/test/to-tex.test.ts
@@ -94,6 +94,11 @@ const passedExamples: Examples = [
   { input: '[a, b|; c,d]', output: '\\left[\\begin{array}{cc|}a & b \\\\ c & d\\end{array}\\right]' },
   { input: '[|a, b|; c,d]', output: '\\left[\\begin{array}{|cc|}a & b \\\\ c & d\\end{array}\\right]' },
   { input: '[|hline 1| 2|; hline 3, 4; hline]', output: '\\left[\\begin{array}{|c|c|}\\hline 1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hline\\end{array}\\right]' },
+  { input: '"\\\\abc"', output: '\\text{\\abc}' },
+  { input: '==^b_a', output: '\\xlongequal[ a ]{ b }' },
+  { input: '-->^114_5', output: '\\xrightarrow[ 5 ]{ 114 }' },
+  { input: '& 1111\n\n& 2222', output: '\\begin{aligned}& 1111 \\\\ & 2222\\end{aligned}' },
+  { input: 'hline\na && 111 && 333\n\nhline\nb && 222\n\nhline', output: '\\begin{aligned}\\hline a && 111 && 333 \\\\ \\hline b && 222 \\\\ \\hline\\end{aligned}' },
 ]
 
 const todoExamples: Examples = [

--- a/packages/nearley/test/to-tex.test.ts
+++ b/packages/nearley/test/to-tex.test.ts
@@ -97,8 +97,21 @@ const passedExamples: Examples = [
   { input: '"\\\\abc"', output: '\\text{\\abc}' },
   { input: '==^b_a', output: '\\xlongequal[ a ]{ b }' },
   { input: '-->^114_5', output: '\\xrightarrow[ 5 ]{ 114 }' },
+  { input: '==^b', output: '\\xlongequal[  ]{ b }' },
+  { input: '==_a', output: '\\xlongequal[ a ]{  }' },
   { input: '& 1111\n\n& 2222', output: '\\begin{aligned}& 1111 \\\\ & 2222\\end{aligned}' },
   { input: 'hline\na && 111 && 333\n\nhline\nb && 222\n\nhline', output: '\\begin{aligned}\\hline a && 111 && 333 \\\\ \\hline b && 222 \\\\ \\hline\\end{aligned}' },
+  { input: '[hline|a|b|;]', output: '\\left[\\begin{array}{|c|c|}\\hline a & b \\\\ \\end{array}\\right]' },
+  {
+    input: `{:
+  --
+  |a|b|;
+  --
+  c, d;
+  --
+:}`,
+    output: '\\left.\\begin{array}{|c|c|}\\hline a & b \\\\ \\hline c & d \\\\ \\hline\\end{array}\\right.',
+  },
 ]
 
 const todoExamples: Examples = [


### PR DESCRIPTION
- multiline formula:
  ```
  y &= x + x

  &= 2x
  ```
- limits:
  ```
  ==^a_b, -->^a_b, ==^a
  ```
- allow hline before pipe in matrix.
  previous grammar:
  ```
  {:
  | hline a|b|;
  hline
  c, d;
  hline
  :}
  ```
  new grammar:
  ```
  {:
  --
  |a|b|;
  --
  c, d;
  --
  :}
  ```
- added new symbol `varPhi`, `$`, `--` to am.