### PR TITLE
Nearley: unicode support, verbatim env and pretty print error msg

### DIFF
--- a/packages/nearley/README.md
+++ b/packages/nearley/README.md
@@ -4,8 +4,7 @@ Another asciimath parser based on [nearley](https://nearley.js.org).
 
 > **Warning**
 > This library is heavily working in progress, so currently there is no npm package available.
-> In addition, some rules are not consistent with `asciimath-parser`, and it does not support
-> unicode currently.
+> In addition, some rules are not consistent with `asciimath-parser`.
 
 If want to preview this library, you can visit https://asciimath.widcard.win and click on the <kbd>Nearley<sup>Beta</sup></kbd> button, then the formulas will be parsed by Asciimath Parser Nearley.
 
@@ -13,30 +12,70 @@ If want to preview this library, you can visit https://asciimath.widcard.win and
 
 - [x] `==_a^b`
 - [x] multiline formulas
-- [ ] backslashes in backtick
-- [ ] single paren
-- [ ] unicode support
+- [x] unicode support
+- [x] escape backslashes in text like `"\\"`
+- [x] vabatim environment
+  ```text
+  verb "aaa
+  bbb"
+  ```
+  translates to
+  ```tex
+  \\begin{aligned}
+  & \\texttt{aaa} \\
+  & \\texttt{bbb}
+  \\end{aligned}
+  ```
+- [ ] single paren case like `(` and `)`
+- [ ] table syntax sugar
+  ```text
+  table[
+  a, b, c;
+  d, e, f;
+  ]
+  ```
+  is equal to
+  ```text
+  {:
+  --
+  |a|b|c|
+  --
+  d, e, f;
+  --
+  :}
+  ```
 
 ## Differences
 
-Asciimath Parser **Core** version is written in pure TypeScript, and we may 
+Asciimath Parser **Core** version is written in pure TypeScript, and we may
 fail to consider some edge cases, so please report any issue if you run into
 any error.
 
 Asciimath Parser **Nearley** version is parsed with nearley grammar, so it is
 **strict** and you **have to write correct formulas**.
 
-| output | asciimath parser | AM nearley version |
+About string literal: In **Nearley** version, text have to be quoted with `"` to skip tokenize, for example the argument of `color`, `tex`, and `hspace` command must be quoted. You can use escape sequences `\"` and `\\` in a string literal.
+
+| output | AM core | AM nearley |
 | ------ | ---------------- | ------------------ |
 | ${\color{red} a}$ | `color(red)(a)` | `color"red" a` |
 | $\text{text}$ | `text(text)` | `text"text"` |
+| $a\hspace{12pt}b$ | `a hspace(12pt) b` | `a hspace"12pt" b` |
 | $\frac{\partial L}{\partial \sigma^2}$ | `pp L (sigma^2)` | `pp L sigma^2` or `pp L (sigma^2)` |
 
 ## New Grammar
 
+Added new infix symbol `over`, `atop` and `choose`:
+
+```text
+a over b,
+a atop b,
+a choose b
+```
+
 Added new symbol `--` which will be transformed into `\hline`. You can draw a table like this
 
-```
+```text
 {:
 --
 |a|b|;
@@ -44,6 +83,16 @@ Added new symbol `--` which will be transformed into `\hline`. You can draw a ta
 c, d;
 --
 :}
+```
+
+Verbatim environment (experimental)
+
+```text
+verb"#include<stdio.h>
+int main() {
+  printf(\"hello, world!\n\");
+  return 0;
+}"
 ```
 
 ## How to dev
@@ -56,7 +105,7 @@ The parser core is _`parser.ne`_. After changing the file, you should run the fo
 pnpm run nearley
 ```
 
-Then the _`index.ts`_ will export `AsciiMath` properly. You can use it like below, and the params are the same as `asciimath-parser`.
+Then the _`index.ts`_ will export `AsciiMath` properly. You can use it like below, and the params are  *almost* the same as `asciimath-parser`.
 
 ```ts
 const am = new AsciiMath()
@@ -64,3 +113,29 @@ const tex = am.toTex('sum_(n=1)^(+oo)1/n^2=pi^2/6')
 console.log(tex)
 // \displaystyle{ \sum_{ n = 1 }^{ + \infty } \frac{ 1 }{ n^2 } = \frac{ \pi^2 }{ 6 } }
 ```
+
+### Different params
+
+- **symbols: Symbols**
+
+  In AsciiMath Nearley version, We removed the `extConst` param, and added `symbols` param:
+  ```ts
+  const am = new AsciiMath({
+    keyword: {
+      dx: { tex: '{\\text{d}x}' },
+      dy: { tex: '{\\text{d}y}' },
+      dz: { tex: '{\\text{d}z}' },
+      dt: { tex: '{\\text{d}t}' },
+      ee: { tex: '\\text{e}' },
+      ii: { tex: '\\text{i}' },
+    },
+    opOAB: {
+      fbox: { tex: '\\fbox[ $2 ]{ $1 }' },
+    },
+  })
+  ```
+- **throws: boolean**
+
+  If true, throws error when parser encounters any syntax error.
+  If false, just output error message as a text string.
+  Default is false.

--- a/packages/nearley/src/index.ts
+++ b/packages/nearley/src/index.ts
@@ -118,8 +118,17 @@ class AsciiMath {
         throw e
       console.error(e)
       const message = String(e)
-      const index = message.indexOf(':\n')
-      const end = index === -1 ? undefined : index
+      let index = message.indexOf(' Instead, I was expecting to see one of the following:')
+      if (index > -1) {
+        return this.generator({
+          type: 'opOA',
+          value: 'verb',
+          $1: { value: message.slice(0, index) },
+        })
+      }
+
+      index = message.indexOf(':\n')
+      const end = index > -1 ? index : undefined
       return `\\text{${message.slice(0, end)}}`
     }
   }

--- a/packages/nearley/src/lexer.ts
+++ b/packages/nearley/src/lexer.ts
@@ -60,16 +60,15 @@ const initLexer = (symbols: Symbols) => {
       literal: /\S/u,
     },
     text: {
-      textEnd: { match: /"/u, pop: 1 },
       /**
-       * 匹配一个非空串，允许包含所有非换行的字符，即 /.+/
+       * 匹配一个非空串，允许包含所有字符，即 /[^]+/
        * 但是，串里面的双引号必须紧跟在反斜杠后面，即 \"
        * 比如下面这个串满足条件:
        * ab\"c
        * 下面这个不满足，因为 " 没有紧跟在 \ 后面:
        * ab"c
        */
-      textContent: /(?:\\"|[^\n"])+/u,
+      textEnd: { match: /(?:\\"|[^"])*"/u, lineBreaks: true, pop: 1 },
     },
   })
 }

--- a/packages/nearley/src/parser.ne
+++ b/packages/nearley/src/parser.ne
@@ -103,7 +103,7 @@ simple -> matrix {% id %} # 矩阵
   # 二元操作符
   | %opOAB _ simple _ simple {% d => ({ type: 'opOAB', value: d[0].value, $1: d[2], $2: d[4] }) %}
   # 文本
-  | %text %textContent:? %textEnd {%d => ({ type: 'text', value: d[1] ? d[1].value : '' }) %}
+  | %text %textEnd {%d => ({ type: 'text', value: d[1] ? d[1].value : '' }) %}
   | %limits {% id %}
   | %align {% id %}
   | value {% id %}

--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -308,6 +308,7 @@ const symbols: Required<Symbols> = {
     phantom: { tex: '\\phantom{ $1 }' },
     text: { tex: '\\text{$1}' },
     tex: { tex: '{ $1 }' },
+    verb: { tex: '' }, // 这里 tex 没有实际意义, verb 需特殊处理
     mbox: { tex: '\\mbox{$1}' },
     op: { tex: '\\operatorname{ $1 }' },
     cancel: { tex: '\\cancel{ $1 }' },

--- a/packages/nearley/test/to-tex.test.ts
+++ b/packages/nearley/test/to-tex.test.ts
@@ -112,6 +112,8 @@ const passedExamples: Examples = [
 :}`,
     output: '\\left.\\begin{array}{|c|c|}\\hline a & b \\\\ \\hline c & d \\\\ \\hline\\end{array}\\right.',
   },
+  { input: '\uD83D\uDC40', output: '\uD83D\uDC40' },
+  { input: '🍎/(🍌+🍍) + 🍌/(🍍+🍎) + 🍍/(🍎+🍌) = 4', output: '\\frac{ 🍎 }{ 🍌 + 🍍 } + \\frac{ 🍌 }{ 🍍 + 🍎 } + \\frac{ 🍍 }{ 🍎 + 🍌 } = 4' },
 ]
 
 const todoExamples: Examples = [

--- a/packages/nearley/test/to-tex.test.ts
+++ b/packages/nearley/test/to-tex.test.ts
@@ -4,7 +4,7 @@ import initSymbols from '../src/symbols'
 import initLexer from '../src/lexer'
 import initGrammar from '../src/grammar.js'
 import initGenerator from '../src/to-tex'
-import { AsciiMath } from '../../core/src/index'
+import { AsciiMath } from '../src/index'
 
 const symbols = initSymbols({
   keyword: {
@@ -114,6 +114,8 @@ const passedExamples: Examples = [
   },
   { input: '\uD83D\uDC40', output: '\uD83D\uDC40' },
   { input: '🍎/(🍌+🍍) + 🍌/(🍍+🍎) + 🍍/(🍎+🍌) = 4', output: '\\frac{ 🍎 }{ 🍌 + 🍍 } + \\frac{ 🍌 }{ 🍍 + 🍎 } + \\frac{ 🍍 }{ 🍎 + 🍌 } = 4' },
+  { input: 'verb"114514\n1919810"', output: '\\begin{aligned}\n& \\texttt{114514}\\\\\n& \\texttt{1919810}\n\\end{aligned}' },
+  { input: '"\\\\"', output: '\\text{\\}' },
 ]
 
 const todoExamples: Examples = [
@@ -122,6 +124,20 @@ const todoExamples: Examples = [
 // no idea why this fails ˉ\_(ツ)_/ˉ
 const whyThisFails: Examples = [
   { input: '"\\"abc\\""', output: '\\text{"abc"}' },
+  {
+    input: String.raw`verb"#include<stdio.h>
+int main() {
+  printf(\"hello, world!\n\");
+  return 0;
+}"`,
+    output: String.raw`\begin{aligned}
+& \texttt{\#include<stdio.h>}\\
+& \texttt{int\ main()\ \{}\\
+& \texttt{\ \ printf("hello,\ world!\textbackslash{}n");}\\
+& \texttt{\ \ return\ 0;}\\
+& \texttt{\}}
+\end{aligned}`,
+  },
 ]
 
 const examples: Examples = [
@@ -165,6 +181,19 @@ describe('test nearley', () => {
     })
   })
 })
+
+// describe('test error', () => {
+//   const am = new AsciiMath()
+//   it('syntax error', () => {
+//     expect(am.toTex('/')).toBe(String.raw`\begin{aligned}
+// & \texttt{Error:\ Syntax\ error\ at\ line\ 1\ col\ 1:}\\
+// & \texttt{}\\
+// & \texttt{1\ \ /}\\
+// & \texttt{\ \ \ \textasciicircum{}}\\
+// & \texttt{Unexpected\ opAOB\ token:\ "/"}
+// \end{aligned}`)
+//   })
+// })
 
 // describe('test core', () => {
 //   const am = new AsciiMath({ display: false })


### PR DESCRIPTION
- fix: unicode emoji compatibility problem
- fix: escape backslashes in text `"\\"`
- feat: verbatim environment `verb"..."`
- feat: pretty print of error message: try to type this single character in am: `/`, check this pretty-aligned error output:
  ```
  Error: Syntax error at line 1 col 1:
  
  1  /
     ^
  Unexpected opAOB token: "/"
  ```
For more examples, please refer to `nearley/README.md` and the test suite.