### PR TITLE
Fix: add strip option to opAO in nearley

### DIFF
--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -16,6 +16,7 @@ export enum TokenTypes {
 
 interface SymbolConfig {
   tex: string
+  strip?: boolean
 }
 
 export interface Symbols {
@@ -396,8 +397,8 @@ const symbols: Required<Symbols> = {
     dd: { tex: '\\text{d}' },
   },
   opAO: {
-    '!!': { tex: '{ $1!! }' },
-    '!': { tex: '{ $1! }' },
+    '!!': { tex: '{ $1!! }', strip: false }, // strip: false 时, op 的参数不会脱去括号
+    '!': { tex: '{ $1! }', strip: false },
   },
   opAOB: {
     '/': { tex: '\\frac{ $1 }{ $2 }' },

--- a/packages/nearley/src/to-tex.ts
+++ b/packages/nearley/src/to-tex.ts
@@ -90,12 +90,13 @@ const initGenerator = (symbols: Required<Symbols>) => {
     const { type, value, $1, $2 } = ast
     if (value === 'verb')
       return genVerb(ast)
-    let res = symbols[type as TokenTypes][value].tex
+    const symbol = symbols[type as TokenTypes][value]
+    let { tex, strip = true } = symbol
     if ($1)
-      res = res.replace('$1', toTex($1, true))
+      tex = tex.replace('$1', toTex($1, strip))
     if ($2)
-      res = res.replace('$2', toTex($2, true))
-    return res
+      tex = tex.replace('$2', toTex($2, strip))
+    return tex
   }
 
   const escapeText = (str: string): string => {

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -110,6 +110,8 @@ int main() {
 & \verb|}|
 \end{aligned}`,
   },
+  { input: '(a)!', output: '{ \\left(a\\right)! }' }, // test op strip
+  { input: '(n) choose (k) = n!/(n!(n-k)!)', output: '{ n \\choose k } = \\frac{ { n! } }{ { n! } { \\left(n - k\\right)! } }' },
 ]
 
 // no idea why this fails ˉ\_(ツ)_/ˉ


### PR DESCRIPTION
In current version of asciimath-parser-nearley, a pair of parenthesis is removed before passing arguments to an operator.
Thus `(n-k)!` will produce tex string like `{ n-k! }`, which is missing parenthesis.

**Change**: make `strip = false` in symbol `!` and `!!`, now `(n-k)!` will produce `{ \left(n-k\right)! }`.