### PR TITLE
Fix am-nearley: whitespace compat for \r \v \f

### DIFF
--- a/packages/nearley/src/index.ts
+++ b/packages/nearley/src/index.ts
@@ -67,6 +67,9 @@ function resolveConfig(config?: AsciiMathConfig): RestrictedAmConfig {
       ...config?.symbols,
     },
     replaceBeforeTokenizing: [
+      // line break compat
+      [/\r\n/g, '\n'],
+      [/\r/g, '\n'],
       // html entity
       [/&#(x?[0-9a-fA-F]+);/g, (_match, $1) =>
         String.fromCodePoint($1[0] === 'x' ? `0${$1}` : $1),

--- a/packages/nearley/src/lexer.ts
+++ b/packages/nearley/src/lexer.ts
@@ -24,7 +24,7 @@ const initLexer = (symbols: Symbols) => {
   const main = {
     newlines: { match: /\n{2,}/u, lineBreaks: true },
     newline: { match: '\n', lineBreaks: true },
-    space: /[ \t]+/u,
+    space: /[ \t\v\f]+/u,
     number: /[0-9]+\.[0-9]+|[0-9]+/u,
     text: { match: /"/u, push: 'text' },
     lp: { match: loadSymbol(TokenTypes.lp), push: 'lp' },

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -131,6 +131,9 @@ int main() {
 & \verb|\}|
 \end{aligned}`,
   },
+  { input: 'a\r\n', output: 'a' },
+  { input: '& a\r\n\r& b\n\r& c', output: '\\begin{aligned}& a \\\\ & b \\\\ & c\\end{aligned}' },
+  { input: 'a\t\v\f', output: 'a' },
 ]
 
 const todoExamples: Examples = [


### PR DESCRIPTION
Fix lexer error when inputting `\r`, `\r\n`, `\v` and `\f`