### PR TITLE
Fix double quote strip

### DIFF
--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -14,9 +14,14 @@ export enum TokenTypes {
   pipe = 'pipe',
 }
 
+export type StripType = (boolean | undefined) | (boolean | undefined)[]
+
 interface SymbolConfig {
   tex: string
-  strip?: boolean
+  // strip 为 true 时, 全脱
+  // strip 为 false 时, 全不脱
+  // strip 为 undefined 时, 脱括号, 不脱引号
+  strip?: StripType
   mid?: string
 }
 
@@ -314,14 +319,14 @@ const symbols: Required<Symbols> = {
     obrace: { tex: '\\overbrace{ $1 }' },
     phantom: { tex: '\\phantom{ $1 }' },
     mbox: { tex: '\\mbox{$1}' },
-    op: { tex: '\\operatorname{ $1 }' },
+    op: { tex: '\\operatorname{ $1 }', strip: true },
     // TODO: \cancel is not supported by web mathjax, but supported by mathjax tex2svg?
     cancel: { tex: '\\cancel{ $1 }' },
 
     // literal string
-    hspace: { tex: '\\hspace{$1}' },
-    text: { tex: '\\text{$1}' },
-    tex: { tex: '{ $1 }' },
+    hspace: { tex: '\\hspace{$1}', strip: true },
+    text: { tex: '\\text{$1}', strip: true },
+    tex: { tex: '{ $1 }', strip: true },
     verb: { tex: '' }, // 这里 tex 没有实际意义, verb 需特殊处理
 
     // font style
@@ -343,7 +348,7 @@ const symbols: Required<Symbols> = {
     scr: { tex: '\\mathscr{ $1 }' },
     mathscr: { tex: '\\mathscr{ $1 }' },
 
-    limits: { tex: '\\mathop{ $1 }\\limits' },
+    limits: { tex: '\\mathop{ $1 }\\limits', strip: true },
 
     // font size
     tiny: { tex: '{ \\tiny $1 }' },
@@ -358,7 +363,7 @@ const symbols: Required<Symbols> = {
     stackrel: { tex: '\\stackrel{ $1 }{ $2 }' },
     overset: { tex: '\\overset{ $1 }{ $2 }' },
     underset: { tex: '\\under{ $1 }{ $2 }' },
-    color: { tex: '{ \\color{$1} $2 }' }, // first param is literal string
+    color: { tex: '{ \\color{$1} $2 }', strip: [true, undefined] }, // first param is literal string
   },
   lp: {
     '(': { tex: '(' },

--- a/packages/nearley/src/to-tex.ts
+++ b/packages/nearley/src/to-tex.ts
@@ -82,10 +82,10 @@ const initGenerator = (symbols: Required<Symbols>) => {
   }
 
   const genLimits = (ast: Ast) => {
-    const { value, sub, sup, $1, $2 } = ast
+    const { value, sub, sup, $1, $2, strip } = ast
     const res = symbols.limits[value.value].tex
-    const tex1 = sub ? toTex($1, true) : ''
-    const tex2 = sup ? toTex($2, true) : ''
+    const tex1 = sub ? toTex($1, shouldStrip($1, strip, 0)) : ''
+    const tex2 = sup ? toTex($2, shouldStrip($2, strip, 1)) : ''
     return res.replace('$1', tex1)
       .replace('$2', tex2)
   }

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -127,6 +127,7 @@ int main() {
   { input: 'a\r\n', output: 'a' },
   { input: '& a\r\n\r& b\n\r& c', output: '\\begin{aligned}& a \\\\ & b \\\\ & c\\end{aligned}' },
   { input: 'a\t\v\f', output: 'a' },
+  { input: '==^"abc"', output: '\\xlongequal[  ]{ \\text{abc} }' },
 ]
 
 // no idea why this fails ˉ\_(ツ)_/ˉ

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -1,6 +1,6 @@
 type Examples = { input: string; output: string; desc?: string }[]
 
-const $_ = String.raw
+const $ = String.raw
 
 const passedExamples: Examples = [
   { input: '    ', output: '' },
@@ -36,6 +36,7 @@ const passedExamples: Examples = [
   { input: 'ppfx', output: '\\frac{ \\partial f }{ \\partial x }' },
   { input: 'pp {::} x', output: '\\frac{ \\partial  }{ \\partial x }' },
   { input: 'pp^3 f (x y^2)', output: '\\frac{ \\partial^3 f }{ \\partial x\\partial y^2 }' },
+  { input: 'dd^2 (bm r) s', output: $`\frac{ \text{d}^2 \boldsymbol{ r } }{ \text{d} s^2 }` },
   { input: 'abs(x)', output: '\\left|x\\right|' },
   { input: '{ a | b }', output: '\\left\\lbrace{}a \\mid b\\right\\rbrace' },
   { input: '(a,b)', output: '\\left(a, b\\right)' },
@@ -100,12 +101,12 @@ const passedExamples: Examples = [
   { input: 'verb"114514\n1919810"', output: '\\begin{aligned}\n& \\verb|114514|\\\\\n& \\verb|1919810|\n\\end{aligned}' },
   { input: '"\\\\"', output: '\\text{\\}' },
   {
-    input: String.raw`verb"#include<stdio.h>
+    input: $`verb"#include<stdio.h>
 int main() {
   if (a || b) printf(b);
   return 0;
 }"`,
-    output: String.raw`\begin{aligned}
+    output: $`\begin{aligned}
 & \verb|#include<stdio.h>|\\
 & \verb|int main() {|\\
 & \verb|  if (a |\verb%|%\verb||\verb%|%\verb| b) printf(b);|\\
@@ -115,24 +116,29 @@ int main() {
   },
   { input: '(a)!', output: '{ \\left(a\\right)! }' }, // test op strip
   { input: '(n) choose (k) = n!/(n!(n-k)!)', output: '{ n \\choose k } = \\frac{ { n! } }{ { n! } { \\left(n - k\\right)! } }' },
-  { input: 'limits(theta)_(k=1)^K', output: $_`\mathop{ \theta }\limits_{ k = 1 }^K` },
-  { input: 'limits(tex"\\Vert")_(k=1)^K', output: $_`\mathop{ { \Vert } }\limits_{ k = 1 }^K` },
-  { input: '|a_n|/2', output: $_`\frac{ \left|a_n\right| }{ 2 }` },
-  { input: '(|a|+|b|)', output: $_`\left(\left|a\right|+\left|b\right|\right)` },
-  { input: '(|a|+|b|+|c)', output: $_`\left(\left|a\right|+\left|b\right|+ \mid c\right)` },
-  { input: '(||a||+|b|+|c)', output: $_`\left(\left\|a\right\|+\left|b\right|+ \mid c\right)` },
+  { input: 'limits(theta)_(k=1)^K', output: $`\mathop{ \theta }\limits_{ k = 1 }^K` },
+  { input: 'limits(tex"\\Vert")_(k=1)^K', output: $`\mathop{ { \Vert } }\limits_{ k = 1 }^K` },
+  { input: '|a_n|/2', output: $`\frac{ \left|a_n\right| }{ 2 }` },
+  { input: '(|a|+|b|)', output: $`\left(\left|a\right|+\left|b\right|\right)` },
+  { input: '(|a|+|b|+|c)', output: $`\left(\left|a\right|+\left|b\right|+ \mid c\right)` },
+  { input: '(||a||+|b|+|c)', output: $`\left(\left\|a\right\|+\left|b\right|+ \mid c\right)` },
+  { input: '[a;b]/2', output: $`\frac{ \begin{array}{c}a \\ b\end{array} }{ 2 }` }, // 脱去矩阵括号
+  { input: '"abc"/2', output: $`\frac{ \text{abc} }{ 2 }` }, // 不脱去引号
+  { input: 'a\r\n', output: 'a' },
+  { input: '& a\r\n\r& b\n\r& c', output: '\\begin{aligned}& a \\\\ & b \\\\ & c\\end{aligned}' },
+  { input: 'a\t\v\f', output: 'a' },
 ]
 
 // no idea why this fails ˉ\_(ツ)_/ˉ
 const whyThisFails: Examples = [
   { input: '"\\"abc\\""', output: '\\text{"abc"}' },
   {
-    input: String.raw`verb"#include<stdio.h>
+    input: $`verb"#include<stdio.h>
 int main() {
   printf(\"hello, world!\n\");
   return 0;
 }"`,
-    output: String.raw`\begin{aligned}
+    output: $`\begin{aligned}
 & \verb|\#include<stdio.h>|\\
 & \verb|int\ main()\ \{|\\
 & \verb|\ \ printf("hello,\ world!\textbackslash{}n");|\\
@@ -140,10 +146,6 @@ int main() {
 & \verb|\}|
 \end{aligned}`,
   },
-  { input: 'a\r\n', output: 'a' },
-  { input: '& a\r\n\r& b\n\r& c', output: '\\begin{aligned}& a \\\\ & b \\\\ & c\\end{aligned}' },
-  { input: 'a\t\v\f', output: 'a' },
-  { input: 'dd^2 (bm r) s', output: '\frac{ \text{d}^2 \boldsymbol{ r } }{ \text{d} s^2 }' },
 ]
 
 const todoExamples: Examples = [


### PR DESCRIPTION
input:
```asciimath
"abc"/2, ==^"abc"
```
before:
```tex
\frac{ abc }{ 2 } , \xlongequal[  ]{ abc }
```
after:
```tex
\frac{ \text{abc} }{ 2 } , \xlongequal[  ]{ \text{abc} }
```