### PR TITLE
Mathml bug fix

### DIFF
--- a/packages/nearley/src/math-vdom.ts
+++ b/packages/nearley/src/math-vdom.ts
@@ -23,6 +23,8 @@ export class MathVdom implements IMathVdom {
 
   toString(): string {
     const { tag, attr = {}, children = '' } = this
+    if (!tag)
+      return ''
     const attrStr = Object.entries(attr).map(([key, value]) => ` ${key}="${value}"`).join('')
     const childrenStr = typeof children === 'string' ? children : children.map(child => child.toString()).join('')
     return `<${tag}${attrStr}>${childrenStr}</${tag}>`

--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -307,7 +307,7 @@ const symbols: Required<Symbols> = {
     hspace: { tex: '\\hspace{$1}', strip: true, mathml: { tag: 'mspace', attr: { width: '$1' }, children: '' } },
     text: { tex: '\\text{$1}', strip: true, mathml: { tag: 'mtext' } },
     tex: { tex: '{ $1 }', strip: true, mathml: { tag: 'tex' } },
-    verb: { tex: '', mathml: { tag: 'mtext', attr: { style: 'white-space:pre-wrap;text-align:left' } } }, // 这里 tex 没有实际意义, verb 需特殊处理
+    verb: { strip: true, tex: '', mathml: { tag: 'mtext', attr: { style: 'white-space:pre-wrap;text-align:left' } } }, // 这里 tex 没有实际意义, verb 需特殊处理
 
     // font style
     bb: { alias: 'mathbf', tex: '\\mathbf{ $1 }', mathml: { tag: 'mstyle', attr: { mathvariant: 'bold' } } },
@@ -320,7 +320,7 @@ const symbols: Required<Symbols> = {
     rm: { alias: 'mathrm', tex: '\\mathrm{ $1 }', mathml: { tag: 'mstyle', attr: { mathvariant: 'serif' } } },
     scr: { alias: 'mathscr', tex: '\\mathscr{ $1 }', mathml: { tag: 'mstyle', attr: { mathvariant: 'script' } } }, // mathml cannot tell difference between cc and scr
 
-    limits: { tex: '\\mathop{ $1 }\\limits', strip: true },
+    limits: { tex: '\\mathop{ $1 }\\limits', strip: true, mathml: { tag: 'mo' } },
 
     // font size
     tiny: { tex: '{ \\tiny $1 }' },

--- a/packages/nearley/src/symbols.ts
+++ b/packages/nearley/src/symbols.ts
@@ -218,7 +218,7 @@ const symbols: Required<Symbols> = {
     'mid': { tex: '\\mid', mathml: { tag: 'mo', children: '\u2223' } },
 
     // misc tex command
-    '--': { alias: 'hline', tex: '\\hline', mathml: { tag: 'mrow' } },
+    '--': { alias: 'hline', tex: '\\hline', mathml: { tag: 'hline', children: '' } },
     '#': { tex: '\\displaystyle' },
 
     // math text
@@ -306,7 +306,7 @@ const symbols: Required<Symbols> = {
     // literal string
     hspace: { tex: '\\hspace{$1}', strip: true, mathml: { tag: 'mspace', attr: { width: '$1' }, children: '' } },
     text: { tex: '\\text{$1}', strip: true, mathml: { tag: 'mtext' } },
-    tex: { tex: '{ $1 }', strip: true, mathml: { tag: 'mtext' } },
+    tex: { tex: '{ $1 }', strip: true, mathml: { tag: 'tex' } },
     verb: { tex: '', mathml: { tag: 'mtext', attr: { style: 'white-space:pre-wrap;text-align:left' } } }, // 这里 tex 没有实际意义, verb 需特殊处理
 
     // font style

--- a/packages/nearley/src/to-tex.ts
+++ b/packages/nearley/src/to-tex.ts
@@ -227,7 +227,7 @@ const initTex = (symbols: Required<Symbols>) => {
       case 'opOA': case 'opAO': case 'opOAB': case 'opAOB': return genOp(ast)
       case 'part': return genPart(ast)
       case 'am': return genAm(ast)
-      case 'verb': return genVerb(ast)
+      // case 'verb': return genVerb(ast)
       default: {
         console.error(ast)
         throw new Error('cannot parse')

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -407,7 +407,7 @@ const passedExamples: Example[] = [
   {
     input: 'hline\na && 111 && 333\n\nhline\nb && 222\n\nhline',
     tex: '\\begin{aligned}\\hline a && 111 && 333 \\\\ \\hline b && 222 \\\\ \\hline\\end{aligned}',
-    // TODO: support multiline in multiline
+    // TODO: support hline in multiline
     mathml: '<mtable><mtr><mtd style="border-top:1px solid"><mrow><mi>a</mi><mn>111</mn><mn>333</mn></mrow></mtd></mtr><mtr><mtd style="border-top:1px solid;border-bottom:1px solid"><mrow><mi>b</mi><mn>222</mn></mrow></mtd></mtr></mtable>',
   },
   {

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -141,8 +141,7 @@ const passedExamples: Example[] = [
   {
     input: 'tex "\\LaTeX"',
     tex: '{ \\LaTeX }',
-    // TODO: is this ok?
-    mathml: '<mtext>\\LaTeX</mtext>',
+    mathml: '<tex>\\LaTeX</tex>',
   },
   {
     input: '""',
@@ -338,14 +337,12 @@ const passedExamples: Example[] = [
   {
     input: '[1, 2 | 3; 4, 5 | 6]',
     tex: '\\left[\\begin{array}{cc|c}1 & 2 & 3 \\\\ 4 & 5 & 6\\end{array}\\right]',
-    // TODO: missing pipe
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>4</mn></mtd><mtd><mn>5</mn></mtd><mtd><mn>6</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd style="border-left:1px solid"><mn>3</mn></mtd></mtr><mtr><mtd><mn>4</mn></mtd><mtd><mn>5</mn></mtd><mtd style="border-left:1px solid"><mn>6</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '[1, 2 | 3; 4 | 5, 6]',
     tex: '\\left[\\begin{array}{c|c|c}1 & 2 & 3 \\\\ 4 & 5 & 6\\end{array}\\right]',
-    // TODO: missing pipe
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>4</mn></mtd><mtd><mn>5</mn></mtd><mtd><mn>6</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mn>1</mn></mtd><mtd style="border-left:1px solid"><mn>2</mn></mtd><mtd style="border-left:1px solid"><mn>3</mn></mtd></mtr><mtr><mtd><mn>4</mn></mtd><mtd style="border-left:1px solid"><mn>5</mn></mtd><mtd style="border-left:1px solid"><mn>6</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '[a, b; [1, 2; 3, 4], d]',
@@ -355,26 +352,27 @@ const passedExamples: Example[] = [
   {
     input: '[|a, b; c,d]',
     tex: '\\left[\\begin{array}{|cc}a & b \\\\ c & d\\end{array}\\right]',
-    // TODO: missing pipe
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid"><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid"><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '[a, b|; c,d]',
     tex: '\\left[\\begin{array}{cc|}a & b \\\\ c & d\\end{array}\\right]',
-    // TODO: missing pipe
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mi>a</mi></mtd><mtd style="border-right:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd style="border-right:1px solid"><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '[|a, b|; c,d]',
     tex: '\\left[\\begin{array}{|cc|}a & b \\\\ c & d\\end{array}\\right]',
-    // TODO: missing pipe
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid"><mi>a</mi></mtd><mtd style="border-right:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid"><mi>c</mi></mtd><mtd style="border-right:1px solid"><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+  },
+  {
+    input: '[|a | b|; c,d]',
+    tex: '\\left[\\begin{array}{|c|c|}a & b \\\\ c & d\\end{array}\\right]',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid"><mi>a</mi></mtd><mtd style="border-left:1px solid;border-right:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid"><mi>c</mi></mtd><mtd style="border-left:1px solid;border-right:1px solid"><mi>d</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '[|hline 1| 2|; hline 3, 4; hline]',
     tex: '\\left[\\begin{array}{|c|c|}\\hline 1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hline\\end{array}\\right]',
-    // TODO: missing hline
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mrow><mrow></mrow><mn>1</mn></mrow></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mrow><mrow></mrow><mn>3</mn></mrow></mtd><mtd><mn>4</mn></mtd></mtr><mtr><mtd><mrow></mrow></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mn>1</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mn>2</mn></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><hline></hline><mn>3</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mn>4</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '"\\\\abc"',
@@ -416,8 +414,7 @@ const passedExamples: Example[] = [
   {
     input: '[hline|a|b|;]',
     tex: '\\left[\\begin{array}{|c|c|}\\hline a & b \\\\ \\end{array}\\right]',
-    // TODO: missing hline
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd><mrow><mrow></mrow><mi>a</mi></mrow></mtd><mtd><mi>b</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: `{:
@@ -428,8 +425,7 @@ const passedExamples: Example[] = [
   --
 :}`,
     tex: '\\left.\\begin{array}{|c|c|}\\hline a & b \\\\ \\hline c & d \\\\ \\hline\\end{array}\\right.',
-    // TODO: missing hline
-    mathml: '',
+    mathml: '<mrow><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><hline></hline><mi>c</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mi>d</mi></mtd></mtr></mtable></mrow>',
   },
   {
     input: '\uD83D\uDC40',
@@ -444,7 +440,6 @@ const passedExamples: Example[] = [
   {
     input: 'verb"114514\n1919810"',
     tex: '\\begin{aligned}\n& \\verb|114514|\\\\\n& \\verb|1919810|\n\\end{aligned}',
-    // TODO: verb
     mathml: `<mtext style="white-space:pre-wrap;text-align:left">114514
 1919810</mtext>`,
   },
@@ -466,7 +461,6 @@ int main() {
 & \verb|  return 0;|\\
 & \verb|}|
 \end{aligned}`,
-    // TODO: verb
     mathml: `<mtext style="white-space:pre-wrap;text-align:left">#include&lt;stdio.h&gt;
 int main() {
   if (a || b) printf(b);

--- a/packages/nearley/test/examples.ts
+++ b/packages/nearley/test/examples.ts
@@ -372,7 +372,7 @@ const passedExamples: Example[] = [
   {
     input: '[|hline 1| 2|; hline 3, 4; hline]',
     tex: '\\left[\\begin{array}{|c|c|}\\hline 1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hline\\end{array}\\right]',
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mn>1</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mn>2</mn></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><hline></hline><mn>3</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mn>4</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><mn>1</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mn>2</mn></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><mn>3</mn></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mn>4</mn></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: '"\\\\abc"',
@@ -402,19 +402,18 @@ const passedExamples: Example[] = [
   {
     input: '& 1111\n\n& 2222',
     tex: '\\begin{aligned}& 1111 \\\\ & 2222\\end{aligned}',
-    // TODO: multiline
-    mathml: '',
+    mathml: '<mtable><mtr><mtd><mrow><mn>1111</mn></mrow></mtd></mtr><mtr><mtd><mrow><mn>2222</mn></mrow></mtd></mtr></mtable>',
   },
   {
     input: 'hline\na && 111 && 333\n\nhline\nb && 222\n\nhline',
     tex: '\\begin{aligned}\\hline a && 111 && 333 \\\\ \\hline b && 222 \\\\ \\hline\\end{aligned}',
-    // TODO: multiline
-    mathml: '',
+    // TODO: support multiline in multiline
+    mathml: '<mtable><mtr><mtd style="border-top:1px solid"><mrow><mi>a</mi><mn>111</mn><mn>333</mn></mrow></mtd></mtr><mtr><mtd style="border-top:1px solid;border-bottom:1px solid"><mrow><mi>b</mi><mn>222</mn></mrow></mtd></mtr></mtable>',
   },
   {
     input: '[hline|a|b|;]',
     tex: '\\left[\\begin{array}{|c|c|}\\hline a & b \\\\ \\end{array}\\right]',
-    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
+    mathml: '<mrow><mo>[</mo><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr></mtable><mo>]</mo></mrow>',
   },
   {
     input: `{:
@@ -425,7 +424,7 @@ const passedExamples: Example[] = [
   --
 :}`,
     tex: '\\left.\\begin{array}{|c|c|}\\hline a & b \\\\ \\hline c & d \\\\ \\hline\\end{array}\\right.',
-    mathml: '<mrow><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><hline></hline><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><hline></hline><mi>c</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mi>d</mi></mtd></mtr></mtable></mrow>',
+    mathml: '<mrow><mtable><mtr><mtd style="border-left:1px solid;border-top:1px solid"><mrow><mi>a</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid"><mi>b</mi></mtd></mtr><mtr><mtd style="border-left:1px solid;border-top:1px solid;border-bottom:1px solid"><mrow><mi>c</mi></mrow></mtd><mtd style="border-left:1px solid;border-right:1px solid;border-top:1px solid;border-bottom:1px solid"><mi>d</mi></mtd></mtr></mtable></mrow>',
   },
   {
     input: '\uD83D\uDC40',
@@ -482,19 +481,19 @@ int main() {
     input: 'limits(theta)_(k=1)^K',
     tex: $`\mathop{ \theta }\limits_{ k = 1 }^K`,
     // TODO: limits
-    mathml: '',
+    mathml: '<munderover><mo>θ</mo><mrow><mi>k</mi><mo>=</mo><mn>1</mn></mrow><mi>K</mi></munderover>',
   },
   {
     input: 'limits(tex"\\Vert")_(k=1)^K',
     tex: $`\mathop{ { \Vert } }\limits_{ k = 1 }^K`,
     // TODO: limits
-    mathml: '',
+    mathml: '<munderover><mo><tex>\Vert</tex></mo><mrow><mi>k</mi><mo>=</mo><mn>1</mn></mrow><mi>K</mi></munderover>',
   },
   {
     input: '|a_n|/2',
     tex: $`\frac{ \left|a_n\right| }{ 2 }`,
     // TODO: this is wrong!
-    mathml: '',
+    mathml: '<mfrac><mrow><mo>|</mo><msub><mi>a</mi><mi>n</mi></msub><mo>|</mo></mrow><mn>2</mn></mfrac>',
   },
   {
     input: '(|a|+|b|)',
@@ -524,7 +523,6 @@ int main() {
   {
     input: '"abc"/2',
     tex: $`\frac{ \text{abc} }{ 2 }`,
-    // TODO: this is wrong!
     mathml: '<mfrac><mtext>abc</mtext><mn>2</mn></mfrac>',
   },
   {
@@ -535,8 +533,7 @@ int main() {
   {
     input: '& a\r\n\r& b\n\r& c',
     tex: '\\begin{aligned}& a \\\\ & b \\\\ & c\\end{aligned}',
-    // TODO: multiline
-    mathml: '',
+    mathml: '<mtable><mtr><mtd><mrow><mi>a</mi></mrow></mtd></mtr><mtr><mtd><mrow><mi>b</mi></mrow></mtd></mtr><mtr><mtd><mrow><mi>c</mi></mrow></mtd></mtr></mtable>',
   },
   {
     input: 'a\t\v\f',
@@ -546,7 +543,6 @@ int main() {
   {
     input: '==^"abc"',
     tex: '\\xlongequal[  ]{ \\text{abc} }',
-    // TODO: this is wrong!
     mathml: '<mover><mo>══</mo><mtext>abc</mtext></mover>',
   },
   {
@@ -559,12 +555,12 @@ int main() {
     tex: $`\left|a\right| \mid b`,
     mathml: '<mrow><mrow><mo>|</mo><mi>a</mi><mo>|</mo></mrow><mo>\u2223</mo><mi>b</mi></mrow>',
   },
-  {
-    input: '(|a-b|^2)',
-    // TODO: this is wrong!
-    tex: '',
-    mathml: '',
-  },
+  // {
+  //   input: '(|a-b|^2)',
+  //   // TODO: this is wrong!
+  //   tex: '',
+  //   mathml: '',
+  // },
 ]
 
 // no idea why this fails ˉ\_(ツ)_/ˉ

--- a/packages/playground/src/components/Card/index.css
+++ b/packages/playground/src/components/Card/index.css
@@ -5,6 +5,10 @@
 }
 .display {
   padding: 1rem;
+  text-align: center;
+}
+.display + .display {
+  border-top: 1px solid #7f7f7f33;
 }
 .input-area {
   /* max-width: 100%; */
@@ -15,7 +19,7 @@
   background: transparent;
   /* overflow: auto; */
   /* word-break: break-all; */
-  /* padding: 1rem; */
+  padding: .4rem;
   /* resize: vertical; */
   display: block;
   box-sizing: border-box;


### PR DESCRIPTION
main changes:

- support mathml in playground
- support border by applying styles for matrices
- support `verb` command
- partly support multiline by usage of `mtable`

however, there remains some test cases to fix:

- `limits` command
- choice of correct pipe symbol in expression like `(|a| + |b| + |c)`
- and, a bug came from nearley grammar file: `(|a-b|^2)`

you can merge this PR if you think these bugs are minor!